### PR TITLE
Add "Associated Domain File" for iOS SDK Example app.

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,14 @@ app.get('/logout', (req, res) => {
     req.session.destroy(() => res.redirect('/'));
 });
 
+app.get('/.well-known/apple-app-site-association', (_, res) => {
+    if (config.appId) {
+        res.json({"applinks":{"details":[{"appIDs":[config.appId],"components":[{"/":"/ios_app_login/*"}]}]}})
+    } else {
+        res.end();
+    }
+});
+
 app.use('/browser', filterExt('css', 'ico'), express.static(`${__dirname}/browser`));
 app.get('/favicon.ico', (req, res) => res.redirect('/browser/favicon.ico'));
 app.get('/apple-touch-icon-precomposed.png', (_, res) => res.status(404));

--- a/config.js
+++ b/config.js
@@ -42,4 +42,5 @@ config.alternativeClient.clientId = getenv('ALTERNATIVE_CLIENT_CLIENT_ID', '');
 config.alternativeClient.publisher = getenv('ALTERNATIVE_CLIENT_PAYMENT_PUBLISHER', '');
 config.alternativeClient.redirectUri = getenv('ALTERNATIVE_CLIENT_REDIRECT_URI', '');
 
+config.appId = getenv('APP_ID', '');
 module.exports = config;


### PR DESCRIPTION
Reference: https://developer.apple.com/documentation/safariservices/supporting_associated_domains