### PR TITLE
Support Android App Links

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,6 +116,25 @@ app.get('/.well-known/apple-app-site-association', (_, res) => {
     }
 });
 
+app.get('/.well-known/assetlinks.json', (_, res) => {
+    if (config.androidApps) {
+        const associations = config.androidApps.map(appConfig => {
+            let [packageName, certFingerprint] = appConfig.split('=');
+            return {
+                'relation': ['delegate_permission/common.handle_all_urls'],
+                'target': {
+                    'namespace': 'android_app',
+                    'package_name': packageName,
+                    'sha256_cert_fingerprints': [certFingerprint]
+                }
+            };
+        });
+        res.json(associations)
+    } else {
+        res.end();
+    }
+});
+
 app.use('/browser', filterExt('css', 'ico'), express.static(`${__dirname}/browser`));
 app.get('/favicon.ico', (req, res) => res.redirect('/browser/favicon.ico'));
 app.get('/apple-touch-icon-precomposed.png', (_, res) => res.status(404));

--- a/app.js
+++ b/app.js
@@ -109,8 +109,8 @@ app.get('/logout', (req, res) => {
 });
 
 app.get('/.well-known/apple-app-site-association', (_, res) => {
-    if (config.appId) {
-        res.json({"applinks":{"details":[{"appIDs":[config.appId],"components":[{"/":"/ios_app_login/*"}]}]}})
+    if (config.iosAppIds) {
+        res.json({'applinks':{'details':[{'appIDs':config.iosAppIds,'components':[{'/':'/ios_app_login/*'}]}]}})
     } else {
         res.end();
     }

--- a/config.js
+++ b/config.js
@@ -42,5 +42,5 @@ config.alternativeClient.clientId = getenv('ALTERNATIVE_CLIENT_CLIENT_ID', '');
 config.alternativeClient.publisher = getenv('ALTERNATIVE_CLIENT_PAYMENT_PUBLISHER', '');
 config.alternativeClient.redirectUri = getenv('ALTERNATIVE_CLIENT_REDIRECT_URI', '');
 
-config.appId = getenv('APP_ID', '');
+config.iosAppIds = getenv('IOS_APP_IDS', '').split(',');
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -43,4 +43,5 @@ config.alternativeClient.publisher = getenv('ALTERNATIVE_CLIENT_PAYMENT_PUBLISHE
 config.alternativeClient.redirectUri = getenv('ALTERNATIVE_CLIENT_REDIRECT_URI', '');
 
 config.iosAppIds = getenv('IOS_APP_IDS', '').split(',');
+config.androidApps = getenv('ANDROID_APPS', '').split(',');
 module.exports = config;


### PR DESCRIPTION
Reference: https://developer.android.com/training/app-links/verify-site-associations

Also refactors iOS Universal Links support to allow multiple apps to be associated with SDK Example site.