### PR TITLE
fix: Change in logout logic

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -110,10 +110,11 @@ app.get('/introspect', asyncMW(async (req, res, next) => {
 }));
 
 app.get('/logout', (req, res) => {
-    req.logout();
-    // Destroy the session and any possible data we might have for the user
-    // @see https://www.npmjs.com/package/express-session#sessiondestroycallback
-    req.session.destroy(() => res.redirect('/'));
+    req.logout(() => {
+        // Destroy the session and any possible data we might have for the user
+        // @see https://www.npmjs.com/package/express-session#sessiondestroycallback
+        req.session.destroy(() => res.redirect('/'));
+    });
 });
 
 app.get('/.well-known/apple-app-site-association', (_, res) => {


### PR DESCRIPTION
JIRA: UUI-241

General maintenance, last week alongside the Privacy team, we discovered that the latest version of Passport can break when you run `logout` and `destroy` separately - the session would get destroyed (become undefined) before `logout` was finished with processing it causing a runtime exception.

A simple fix was applied, now `destroy` is called in the callback of `logout`, so only after `logout` is done processing the request object.
