### PR TITLE
chore: bump browser-sdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
+## v5.9.25
+* Use account-sdk-browser version 5.1.1
+
+## v5.9.24
+* Add eID for Denmark
+
 ## v5.9.0
 * Show bankID only for production ENV where it is actually active and we support it
 
 ## v5.8.0
 * Support for norwegian and swedish BankID
-* Use account-sdk-browse in 4.6.0
+* Use account-sdk-browser in 4.6.0
 
 ## v5.7.0
 * Bump node version to 14

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "sdk-example",
-    "version": "5.9.24",
+    "version": "5.9.25",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sdk-example",
-            "version": "5.9.24",
+            "version": "5.9.25",
             "license": "MIT",
             "dependencies": {
-                "@schibsted/account-sdk-browser": "^5.1.0",
+                "@schibsted/account-sdk-browser": "^5.1.1",
                 "axios": "^1.6.5",
                 "cookie-parser": "^1.4.6",
                 "dotenv": "^16.3.1",
@@ -2623,9 +2623,9 @@
             }
         },
         "node_modules/@schibsted/account-sdk-browser": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@schibsted/account-sdk-browser/-/account-sdk-browser-5.1.0.tgz",
-            "integrity": "sha512-oC/lEhpLvvlDFscIXiwrY09gCvw2kHqc9J1NNaKef95UTOrDR5pVG9baD0OA+JAQ26a5tsIzJPjf6QSAC0K9JQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@schibsted/account-sdk-browser/-/account-sdk-browser-5.1.1.tgz",
+            "integrity": "sha512-yG+9dfMyTvDO/d8VE0cSyWxucnwMHB1K4F2JfLpGnIIbSdWDfXsxDaWNNLpCpblJ58hfROGeGhrvIb7U9lqKvw==",
             "dependencies": {
                 "tiny-emitter": "^2.1.0"
             }
@@ -11156,9 +11156,9 @@
             }
         },
         "@schibsted/account-sdk-browser": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@schibsted/account-sdk-browser/-/account-sdk-browser-5.1.0.tgz",
-            "integrity": "sha512-oC/lEhpLvvlDFscIXiwrY09gCvw2kHqc9J1NNaKef95UTOrDR5pVG9baD0OA+JAQ26a5tsIzJPjf6QSAC0K9JQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@schibsted/account-sdk-browser/-/account-sdk-browser-5.1.1.tgz",
+            "integrity": "sha512-yG+9dfMyTvDO/d8VE0cSyWxucnwMHB1K4F2JfLpGnIIbSdWDfXsxDaWNNLpCpblJ58hfROGeGhrvIb7U9lqKvw==",
             "requires": {
                 "tiny-emitter": "^2.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sdk-example",
     "description": "An example website that uses Schibsted's browser SDK",
-    "version": "5.9.24",
+    "version": "5.9.25",
     "license": "MIT",
     "main": "server.js",
     "repository": {
@@ -16,7 +16,7 @@
         "watch": "nodemon server.js"
     },
     "dependencies": {
-        "@schibsted/account-sdk-browser": "^5.1.0",
+        "@schibsted/account-sdk-browser": "^5.1.1",
         "axios": "^1.6.5",
         "cookie-parser": "^1.4.6",
         "dotenv": "^16.3.1",


### PR DESCRIPTION
Update `account-sdk-browser `version to `5.1.1` and release `sdk-example` version `5.9.25`